### PR TITLE
Develop

### DIFF
--- a/robomachine/__init__.py
+++ b/robomachine/__init__.py
@@ -11,8 +11,14 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from StringIO import StringIO
 
 from robomachine.version import VERSION
+from generator import Generator, DepthFirstSearchStrategy
+
 
 __version__ = VERSION
+
+def generate(machine, max_tests=1000, max_actions=None, to_state=None, output=None,
+    strategy=DepthFirstSearchStrategy):
+    generator = Generator()
+    return generator.generate(machine, max_tests, max_actions, to_state, output, strategy)

--- a/robomachine/generator.py
+++ b/robomachine/generator.py
@@ -51,7 +51,8 @@ class Generator(object):
         self._visited_states = strategy_class._visited_states
 
 
-    def generate(self, machine, max_tests=1000, max_actions=None, to_state=None, output=None, strategy=DepthFirstSearchStrategy):
+    def generate(self, machine, max_tests=1000, max_actions=None, to_state=None, output=None,
+                 strategy=DepthFirstSearchStrategy):
         max_actions = -1 if max_actions is None else max_actions
         machine.write_settings_table(output)
         machine.write_variables_table(output)

--- a/robomachine/generator.py
+++ b/robomachine/generator.py
@@ -10,8 +10,7 @@
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
-#  limitations under the License.
-from StringIO import StringIO
+#  limitations under the License.from StringIO import StringIO
 
 from robomachine.parsing import parse
 from robomachine.strategies import DepthFirstSearchStrategy

--- a/robomachine/test/generation_test.py
+++ b/robomachine/test/generation_test.py
@@ -1,5 +1,4 @@
 #  Copyright (c) 2011-2012 Mikko Korpela
-#  Copyright (c) 2017 David Kaplan, handitover.se
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/robomachine/test/generation_test.py
+++ b/robomachine/test/generation_test.py
@@ -24,9 +24,9 @@ class GenerationTestCase(unittest.TestCase):
         mock_machine = RoboMachine(states=[], variables=[], rules=[])
         output = StringIO()
         robomachine.generate(machine=mock_machine, output=output, strategy=_MockStrategyWithNoTests)
-        self.assertEqual('*** Test Cases ***', output.getvalue())
+        self.assertTrue(output.getvalue().startswith('*** Test Cases ***\n*** Keywords ***'))
 
-    def test_generation_with_no_tests(self):
+    def test_generation_with_a_test_limit(self):
         mock_machine = RoboMachine(states=[State('bar', [], [])], variables=[], rules=[])
         output = StringIO()
         robomachine.generate(machine=mock_machine, max_tests=10, output=output, strategy=_MockStrategyWithHundredTests)
@@ -48,6 +48,12 @@ class _MockStrategy(object):
         a = Action('foo', 'bar')
         a.set_machine(self._machine)
         return a
+
+    def _visited_actions(self):
+        pass
+
+    def _visited_states(self):
+        pass
 
 
 class _MockStrategyWithNoTests(_MockStrategy):

--- a/robomachine/test/generation_test.py
+++ b/robomachine/test/generation_test.py
@@ -1,3 +1,18 @@
+#  Copyright (c) 2011-2012 Mikko Korpela
+#  Copyright (c) 2017 David Kaplan, handitover.se
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 from StringIO import StringIO
 import unittest
 from robomachine.model import RoboMachine, State, Action

--- a/sample/webapp/KeywordLibrary.py
+++ b/sample/webapp/KeywordLibrary.py
@@ -1,6 +1,38 @@
 from robot.api import logger
+from random import random
 
 
+# Error-inducing decorators
+def fail_every_nth_time(count):
+    def decorator(fn):
+        def inner(*args, **kwargs):
+            inner._count += 1
+            if inner._count % count == 0:
+                logger.warn('`%s` failed on call count' % fn.__name__)
+                inner._count = 0
+            else:
+                fn(*args, **kwargs)
+            return inner
+        inner._count = 0
+        inner.__name__= fn.__name__
+        return inner
+    return decorator
+
+
+def failure_probability(prob):
+    def decorator(fn):
+        def inner(*args, **kwargs):
+            if random() <= prob:
+                logger.warn('`%s` random failure' % fn.__name__)
+            else:
+                fn(*args, **kwargs)
+            return inner
+        inner.__name__= fn.__name__
+        return inner
+    return decorator
+
+
+# The actual keyword library
 class KeywordLibrary(object):
     """
     This is the implementation of the keywords used in the robomachine test.
@@ -68,6 +100,8 @@ class KeywordLibrary(object):
     def change_state(self, new_state):
         """Set page titles according to current page"""
         if new_state == 'Login Page':
+            self._name = ''
+            self._password = ''
             self._page_title = 'Please log in!'
 
         elif new_state == 'Welcome Page':
@@ -93,7 +127,3 @@ class KeywordLibrary(object):
     def go_to(self, state):
         """Change state"""
         self.change_state(state)
-
-
-
-

--- a/sample/webapp/KeywordLibrary.py
+++ b/sample/webapp/KeywordLibrary.py
@@ -1,15 +1,13 @@
-"""
-The keyword library for the sample webapp.
-
-It it built for educational purposes and it merely mimics responses from a real application.
-"""
 from robot.api import logger
-
 
 
 class KeywordLibrary(object):
     """
-    This is the implementation of the keywords used in the robomachine test
+    This is the implementation of the keywords used in the robomachine test.
+
+    The keywords mimic the behavior of a real application and is intended to
+    be used for educational purposes. Insert errors and re-run the tests
+    to see what happens!
     """
     def __init__(self):
         self._browser = None

--- a/sample/webapp/LICENSE.md
+++ b/sample/webapp/LICENSE.md
@@ -1,0 +1,13 @@
+The files in this folder are all copyright (c) 2017 David Kaplan, handitover.se
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/sample/webapp/model.robomachine
+++ b/sample/webapp/model.robomachine
@@ -11,7 +11,7 @@ ${VALID_PASSWORD}  mypassword
 *** Machine ***
 ${USERNAME}    any of    ${VALID_USERNAME}  ${VALID_PASSWORD}  invalid123  ${EMPTY}
 ${PASSWORD}    any of    ${VALID_PASSWORD}  ${VALID_USERNAME}  password123  ${EMPTY}
-${BROWSER}     any of    Safari    Chrome    Firefox
+${BROWSER}     any of    Safari    Chrome    Firefox    Edge
 
 
 # Add an equivalence rule to reduce the number of generated tests.

--- a/scripts/robomachine
+++ b/scripts/robomachine
@@ -1,19 +1,5 @@
 #! /usr/bin/env python
 
-#  Copyright 2011-2012 Mikko Korpela
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-
 from robomachine.runner import main
 
 main()


### PR DESCRIPTION
Add failure decorators. Fix issues. Add docstrings
 
Failure decorators, useful to add to selected keyword library functions in order to
inject faults and see whether the generated tests will find them:

  - fail_every_nth_time(count):
    skips the actions in the decorated method on every
    _count_ call

 - failure_probability(prob):
    skips the actions in the decorated method when a
    random number is greater than _prob_

 - fail_on_config decorator(dict()). 
    Supply a dict of RobotFramework variable(s) (key) and value(s) (value {string}).
    If there is a match, the decorated function will be skipped
