### PR TITLE
Moved action/state coverage measurements

### DIFF
--- a/robomachine/generator.py
+++ b/robomachine/generator.py
@@ -30,8 +30,8 @@ except ImportError:
 
 class Generator(object):
     def __init__(self):
-        self._visited_states = set()
-        self._visited_actions = set()
+        self.visited_states = set()
+        self.visited_actions = set()
 
     def _write_test(self, name, machine, output, test, values):
         output.write('\n%s\n' % name)
@@ -39,7 +39,11 @@ class Generator(object):
             machine.write_variable_setting_step(values, output)
         machine.start_state.write_to(output)
         for action in test:
+            self.visited_actions.add(action)
+            self.visited_states.add(action._parent_state)
+            self.visited_states.add(action.next_state)
             action.write_to(output)
+
 
     def _write_tests(self, machine, max_tests, max_actions, to_state, output, strategy):
         i = 1
@@ -59,8 +63,6 @@ class Generator(object):
                 generated_tests.add((tuple(test), tuple(values)))
             self._write_test('Test %d' % i, machine, output, test, values)
             i += 1
-        self._visited_actions = strategy_class._visited_actions
-        self._visited_states = strategy_class._visited_states
 
 
     def generate(self, machine, max_tests=1000, max_actions=None, to_state=None, output=None,

--- a/robomachine/runner.py
+++ b/robomachine/runner.py
@@ -150,10 +150,10 @@ def main():
     print('Generated test file: %s' % output_test_file)
 
     # Coverage information:
-    covered_states = generator._visited_states
-    covered_actions = generator._visited_actions
-    uncovered_states = all_states.difference(generator._visited_states)
-    uncovered_actions = all_actions.difference(generator._visited_actions)
+    covered_states = generator.visited_states
+    covered_actions = generator.visited_actions
+    uncovered_states = all_states.difference(generator.visited_states)
+    uncovered_actions = all_actions.difference(generator.visited_actions)
     #
     # Write to STDOUT:
     print('-' * 78)

--- a/robomachine/strategies.py
+++ b/robomachine/strategies.py
@@ -11,13 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#  ------------------------------------------------------------------------
-#  Copyright 2017 David Kaplan
-#
-#  Changes:
-#  - Python 3 support
-#  - Measure covered / uncovered states
-
 import random
 
 class _Strategy(object):
@@ -26,8 +19,6 @@ class _Strategy(object):
         self._machine = machine
         self._max_actions = max_actions
         self._to_state = to_state
-        self._visited_states = set()
-        self._visited_actions = set()
         assert not to_state or self._machine.find_state_by_name(to_state)
 
     def _matching_to_state(self, test):
@@ -61,10 +52,6 @@ class DepthFirstSearchStrategy(_Strategy):
             at_least_one_generated = False
             for action in state.actions:
                 for test in self._generate_all_from(action.next_state, max_actions-1):
-                    action._parent_state = state
-                    self._visited_actions.add(action)
-                    self._visited_states.add(state)
-                    self._visited_states.add(action.next_state)
                     at_least_one_generated = True
                     yield [action]+test
             if not at_least_one_generated and self._to_state == state.name:
@@ -86,10 +73,6 @@ class RandomStrategy(_Strategy):
         current_state = self._machine.start_state
         while self._max_actions > len(test) and current_state.actions:
             action = random.choice(current_state.actions)
-            action._parent_state = current_state
-            self._visited_actions.add(action)
-            self._visited_states.add(current_state)
-            self._visited_states.add(action.next_state)
             current_state = action.next_state
             test.append(action)
         while test and not self._matching_to_state(test):


### PR DESCRIPTION
 - Measurement is performed only in generator.py,
    does not require any modifications of strategies.py
    anymore :)

 - Reverted changes in strategies.py due to this

 - Made private coverage attributes in generator.py public;
    updated runner.py accordingly